### PR TITLE
Remote Validation Changes

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -1908,6 +1908,8 @@ function validatePolicyResult() {
                 result=$( "${jamfBinary}" policy -trigger "${trigger}" | grep "Script result:" )
                 if [[ "${result}" == *"Running"* ]]; then
                     dialogUpdateSetupYourMac "listitem: index: $i, status: success, statustext: Running"
+                elif [[ "${result}" == *"Installed"* || "${result}" == *"Success"*  ]]; then
+                    dialogUpdateSetupYourMac "listitem: index: $i, status: success, statustext: Installed"
                 else
                     dialogUpdateSetupYourMac "listitem: index: $i, status: fail, statustext: Failed"
                     jamfProPolicyTriggerFailure="failed"

--- a/Validations/Check Printer Install.sh
+++ b/Validations/Check Printer Install.sh
@@ -13,6 +13,9 @@
 #   Version 0.0.1, 25-Apr-2023, @drtaru
 #   - Original Version
 #
+#   Version 0.0.2, 25-Apr-2023, @drtaru
+#   - Changed success result to Installed to map to new SYM validation status
+#
 ####################################################################################
 # A script to find printers with lpstat and build an array
 #
@@ -35,5 +38,5 @@ foundPrinters=($(lpstat -p 2>/dev/null | awk '{print $2}' | sed '/^$/d'))
 if [[ ! " ${foundPrinters[*]} " =~ "Printer1" || ! " ${foundPrinters[*]} " =~ "Printer2" ]]; then
     echo "Failure"
 else
-    echo "Running"
+    echo "Installed"
 fi

--- a/Validations/Microsoft Office 365.bash
+++ b/Validations/Microsoft Office 365.bash
@@ -13,8 +13,8 @@
 #   Version 0.0.1, 06-Mar-2023, Dan K. Snelson (@dan-snelson)
 #   - Original Version
 #
-#   Version 0.0.2, 06-Mar-2023, Andrew Clark (@drtaru)
-#   - Simplified modification
+#   Version 0.0.3, 25-Apr-2023, Andrew Clark (@drtaru)
+#   - Changed Success result to Success to map to new SYM validation status
 #
 ####################################################################################
 # A script to collect the installation status of Microsoft Office 365.             #
@@ -86,7 +86,7 @@ done
 
 case "${appChecks}" in
     *"NOT"* ) RESULT="Failure: ${appChecks}" ;;
-    *       ) RESULT="Running: ${appChecks}" ;;
+    *       ) RESULT="Success: ${appChecks}" ;;
 esac
 
 /bin/echo "<result>${RESULT}</result>"


### PR DESCRIPTION
Add Remote Validation results of "Success" or "Installed" to update the List Item with "Installed" instead of "Running"
Change existing Validations for Printers and Office 365 to return "Installed" instead of "Running"