### PR TITLE
Add button to computer record for Slack webhook

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -2337,7 +2337,6 @@ function webHookMessage() {
                                 "text": "View in Jamf Pro"
                                 },
                             "style": "primary",
-                            "value": "view",
                             "url": "${jamfProComputerURL}"
                         }
                     ]

--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -2280,6 +2280,8 @@ function webHookMessage() {
         
         updateScriptLog "Generating Slack Message …"
 
+        jamfProURL=$(/usr/bin/defaults read /Library/Preferences/com.jamfsoftware.jamf.plist jss_url)
+        jamfProComputerURL="${jamfProURL}computers.html?id=${computerID}&o=r"
         
         webHookdata=$(cat <<EOF
         {
@@ -2322,6 +2324,21 @@ function webHookMessage() {
                         {
                             "type": "mrkdwn",
                             "text": "*Additional Comments:*\n${jamfProPolicyNameFailures}"
+                        }
+                    ]
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "View in Jamf Pro"
+                                },
+                            "style": "primary",
+                            "value": "view",
+                            "url": "${jamfProComputerURL}"
                         }
                     ]
                 }


### PR DESCRIPTION
Added a direct link to the computer record in Jamf Pro for Slack webhooks
<img width="570" alt="image" src="https://user-images.githubusercontent.com/1212524/236297917-31ab30b9-9a76-4499-a08f-e6a24e8f0d22.png">
