### PR TITLE
Report on RSR version if applicable

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -136,9 +136,9 @@ supportTeamHelpKB="\n- **Knowledge Base Article:** ${supportKB}"
 
 osVersion=$( sw_vers -productVersion )
 osVersionExtra=$( sw_vers -productVersionExtra ) 
-if [[ -n $osVersionExtra ]]; then osVersion="${osVersion} ${osVersionExtra}"; fi
 osBuild=$( sw_vers -buildVersion )
 osMajorVersion=$( echo "${osVersion}" | awk -F '.' '{print $1}' )
+if [[ -n $osVersionExtra ]] && [[ "${osMajorVersion}" -ge 13 ]]; then osVersion="${osVersion} ${osVersionExtra}"; fi # Report RSR sub version if applicable
 modelName=$( /usr/libexec/PlistBuddy -c 'Print :0:_items:0:machine_name' /dev/stdin <<< "$(system_profiler -xml SPHardwareDataType)" )
 reconOptions=""
 exitCode="0"

--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -135,6 +135,8 @@ supportTeamHelpKB="\n- **Knowledge Base Article:** ${supportKB}"
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 osVersion=$( sw_vers -productVersion )
+osVersionExtra=$( sw_vers -productVersionExtra ) 
+if [[ -n $osVersionExtra ]]; then osVersion="${osVersion} ${osVersionExtra}"; fi
 osBuild=$( sw_vers -buildVersion )
 osMajorVersion=$( echo "${osVersion}" | awk -F '.' '{print $1}' )
 modelName=$( /usr/libexec/PlistBuddy -c 'Print :0:_items:0:machine_name' /dev/stdin <<< "$(system_profiler -xml SPHardwareDataType)" )


### PR DESCRIPTION
After using Erase All Content And Settings on a Mac that has had a RSR installed the RSR persists.
This change will report the subversion (a) (b) etc. in the script logs as well as anywhere else `osVersion` is called in the main script.

Can be held for 1.10.1 as LineNumbers have been shifted.
I primarily wrote this to report RSR value in the Webhook results.