### PR TITLE
Adding forced capitalize for AssetTag

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -96,6 +96,7 @@ promptForUsername="true"
 prefillUsername="true"          # prefills the currently logged in user's username
 promptForComputerName="true"
 promptForAssetTag="true"
+capitalizeAssetTag="true"
 promptForRoom="true"
 promptForConfiguration="true"   # Removes the Configuration dropdown entirely and uses the "Catch-all (i.e., used when `welcomeDialog` is set to `video` or `false`)" policyJSON
 
@@ -2601,7 +2602,11 @@ elif [[ "${welcomeDialog}" == "userInput" ]]; then
 
             computerName=$(get_json_value_welcomeDialog "$welcomeResults" "Computer Name")
             userName=$(get_json_value_welcomeDialog "$welcomeResults" "User Name")
-            assetTag=$(get_json_value_welcomeDialog "$welcomeResults" "Asset Tag")
+			assetTag=$(get_json_value_welcomeDialog "$welcomeResults" "Asset Tag")
+			if [ "$capitalizeAssetTag" == "true" ]; then
+ 			   # Capitalize all alphabetic characters in the asset tag
+				assetTag=$(echo "$assetTag" | tr '[:lower:]' '[:upper:]')
+			fi
             symConfiguration=$(get_json_value_welcomeDialog "$welcomeResults" "Configuration" "selectedValue")
             department=$(get_json_value_welcomeDialog "$welcomeResults" "Department" "selectedValue" | grep -v "Please select your department" )
             room=$(get_json_value_welcomeDialog "$welcomeResults" "Room")


### PR DESCRIPTION
I wanted to allow users to enter asset tags like "P12345" or "p12345" but still have them end up with a capital P. Using the regex i just tell users to use the capital, but with this change we can allow them to type lowercase or not and capture it as capital. 

Added:
capitalizeAssetTag="true" option to allow to flag if the asset tag should be forced to be capital letters. 
Aso
The if statement to check for the flag, if "true" then we use tr to bring letters from lower case to upper case.

This allows the use of a case insensitive regex in the json for the assettag and users dont have to worry about capitalizing the letters. 

Not sure the location of the capital option, but the user input boxes section seemed right, right next to the assetag option