### PR TITLE
Add version check to dialogCheck, Split out install to new function

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -36,7 +36,8 @@
 
 scriptVersion="1.11.0"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
-scriptLog="${4:-"/var/log/org.churchofjesuschrist.log"}"                        # Parameter 4: Script Log Location [ /var/log/org.churchofjesuschrist.log ] (i.e., Your organization's default location for client-side logs)
+scriptLog="${4:-"/var/log/org.symTemp_dialogVersion.log"}"                        # Parameter 4: Script Log Location [ /var/log/org.churchofjesuschrist.log ] (i.e., Your organization's default location for client-side logs)
+#scriptLog="${4:-"/var/log/org.churchofjesuschrist.log"}"                        # Parameter 4: Script Log Location [ /var/log/org.churchofjesuschrist.log ] (i.e., Your organization's default location for client-side logs)
 debugMode="${5:-"verbose"}"                                                     # Parameter 5: Debug Mode [ verbose (default) | true | false ]
 welcomeDialog="${6:-"userInput"}"                                               # Parameter 6: Welcome dialog [ userInput (default) | video | false ]
 completionActionOption="${7:-"Restart Attended"}"                               # Parameter 7: Completion Action [ wait | sleep (with seconds) | Shut Down | Shut Down Attended | Shut Down Confirm | Restart | Restart Attended (default) | Restart Confirm | Log Out | Log Out Attended | Log Out Confirm ]
@@ -362,10 +363,7 @@ toggleJamfLaunchDaemon
 # Pre-flight Check: Validate / install swiftDialog (Thanks big bunches, @acodega!)
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-function dialogCheck() {
-
-    # Output Line Number in `verbose` Debug Mode
-    if [[ "${debugMode}" == "verbose" ]]; then updateScriptLog "PRE-FLIGHT CHECK: # # # SETUP YOUR MAC VERBOSE DEBUG MODE: Line No. ${LINENO} # # #" ; fi
+function dialogInstall() {
 
     # Get the URL of the latest PKG From the Dialog GitHub repo
     dialogURL=$(curl --silent --fail "https://api.github.com/repos/bartreardon/swiftDialog/releases/latest" | awk -F '"' "/browser_download_url/ && /pkg\"/ { print \$4; exit }")
@@ -373,12 +371,9 @@ function dialogCheck() {
     # Expected Team ID of the downloaded PKG
     expectedDialogTeamID="PWA5E9TQ59"
 
-    # Check for Dialog and install if not found
-    if [ ! -e "/Library/Application Support/Dialog/Dialog.app" ]; then
+    updateScriptLog "PRE-FLIGHT CHECK: Installing SwiftDialog..."
 
-        updateScriptLog "PRE-FLIGHT CHECK: Dialog not found. Installing..."
-
-        # Create temporary working directory
+    # Create temporary working directory
         workDirectory=$( /usr/bin/basename "$0" )
         tempDirectory=$( /usr/bin/mktemp -d "/private/tmp/$workDirectory.XXXXXX" )
 
@@ -409,19 +404,40 @@ function dialogCheck() {
         # Remove the temporary working directory when done
         /bin/rm -Rf "$tempDirectory"
 
+}
+
+
+
+function dialogCheck() {
+
+    # Output Line Number in `verbose` Debug Mode
+    if [[ "${debugMode}" == "verbose" ]]; then updateScriptLog "PRE-FLIGHT CHECK: # # # SETUP YOUR MAC VERBOSE DEBUG MODE: Line No. ${LINENO} # # #" ; fi
+
+    # Check for Dialog and install if not found
+    if [ ! -e "/Library/Application Support/Dialog/Dialog.app" ]; then
+
+        updateScriptLog "PRE-FLIGHT CHECK: swiftDialog not found. Installing..."
+        dialogInstall
+
     else
 
-        updateScriptLog "PRE-FLIGHT CHECK: swiftDialog version $(/usr/local/bin/dialog --version) found; proceeding..."
+        dialogVersion=$(/usr/local/bin/dialog --version)
+        if [[ "${dialogVersion}" < "2.2.0.4535" ]]; then
+            
+            updateScriptLog "PRE-FLIGHT CHECK: swiftDialog version ${dialogVersion} found but swiftDialog 2.2 or newer is required; updating..."
+            dialogInstall
+            
+        else
 
+        updateScriptLog "PRE-FLIGHT CHECK: swiftDialog version ${dialogVersion} found; proceeding..."
+
+        fi
+    
     fi
 
 }
 
-if [[ ! -e "/Library/Application Support/Dialog/Dialog.app" ]]; then
-    dialogCheck
-else
-    updateScriptLog "PRE-FLIGHT CHECK: swiftDialog version $(/usr/local/bin/dialog --version) found; proceeding..."
-fi
+dialogCheck
 
 
 

--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -36,8 +36,7 @@
 
 scriptVersion="1.11.0"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
-scriptLog="${4:-"/var/log/org.symTemp_dialogVersion.log"}"                        # Parameter 4: Script Log Location [ /var/log/org.churchofjesuschrist.log ] (i.e., Your organization's default location for client-side logs)
-#scriptLog="${4:-"/var/log/org.churchofjesuschrist.log"}"                        # Parameter 4: Script Log Location [ /var/log/org.churchofjesuschrist.log ] (i.e., Your organization's default location for client-side logs)
+scriptLog="${4:-"/var/log/org.churchofjesuschrist.log"}"                        # Parameter 4: Script Log Location [ /var/log/org.churchofjesuschrist.log ] (i.e., Your organization's default location for client-side logs)
 debugMode="${5:-"verbose"}"                                                     # Parameter 5: Debug Mode [ verbose (default) | true | false ]
 welcomeDialog="${6:-"userInput"}"                                               # Parameter 6: Welcome dialog [ userInput (default) | video | false ]
 completionActionOption="${7:-"Restart Attended"}"                               # Parameter 7: Completion Action [ wait | sleep (with seconds) | Shut Down | Shut Down Attended | Shut Down Confirm | Restart | Restart Attended (default) | Restart Confirm | Log Out | Log Out Attended | Log Out Confirm ]


### PR DESCRIPTION
I added a minimum version check to the `dialogCheck` function and split out the SwiftDialog install portion to it's own function as it is now used twice.

Log output on a machine with an outdated version "`2.1.0.4148`" of SwiftDialog

```
2023-05-28 19:21:27 - PRE-FLIGHT CHECK: # # # SETUP YOUR MAC VERBOSE DEBUG MODE: Line No. 414 # # #
2023-05-28 19:21:28 - PRE-FLIGHT CHECK: swiftDialog version 2.1.0.4148 found but swiftDialog 2.2 or newer is required; updating...
2023-05-28 19:21:28 - PRE-FLIGHT CHECK: Installing SwiftDialog...
installer: Package name is
installer: Upgrading at base path /
installer: The upgrade was successful.
2023-05-28 19:21:32 - PRE-FLIGHT CHECK: swiftDialog version 2.2.0.4535 installed; proceeding...
2023-05-28 19:21:32 - PRE-FLIGHT CHECK: Complete
```

Log output from a machine that does not have SwiftDialog installed.

```
2023-05-28 19:30:03 - PRE-FLIGHT CHECK: # # # SETUP YOUR MAC VERBOSE DEBUG MODE: Line No. 414 # # #
2023-05-28 19:30:03 - PRE-FLIGHT CHECK: swiftDialog not found. Installing...
2023-05-28 19:30:03 - PRE-FLIGHT CHECK: Installing SwiftDialog...
installer: Package name is
installer: Installing at base path /
installer: The install was successful.
2023-05-28 19:30:08 - PRE-FLIGHT CHECK: swiftDialog version 2.2.0.4535 installed; proceeding...
2023-05-28 19:30:08 - PRE-FLIGHT CHECK: Complete
```


