### PR TITLE
Infobox User Input Visual Hiccup

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -2868,7 +2868,7 @@ if [[ -n ${department} ]]; then infobox+="**Department:**  \n$department  \n\n" 
 if [[ -n ${building} ]]; then infobox+="**Building:**  \n$building  \n\n" ; fi
 if [[ -n ${room} ]]; then infobox+="**Room:**  \n$room  \n\n" ; fi
 
-if [[ "${promptForConfiguration}" != "true" ]] || [[ "${welcomeDialog}" == "false" ]]; then
+if ( [[ "${promptForConfiguration}" != "true" ]] && [[ "${configurationDownloadEstimation}" == "true" ]] ) || [[ "${welcomeDialog}" == "false" ]]; then
     updateScriptLog "SETUP YOUR MAC DIALOG: Purposely NOT updating 'infobox'"
 else
     updateScriptLog "SETUP YOUR MAC DIALOG: Updating 'infobox'"


### PR DESCRIPTION
Fix for visual hiccup where the infobox stays on "Analyzing input" if `configurationDownloadEstimation` and `promptForConfiguration` are both set to false.

Preserves intended behavior when `promptForConfiguration` is false and `configurationDownloadEstimation` is true.