### PR TITLE
toggleJamfLaunchDaemon based on CompletionActionOption

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -2534,7 +2534,9 @@ function quitScript() {
     killProcess "caffeinate"
 
     # Toggle `jamf` binary check-in 
-    # toggleJamfLaunchDaemon
+    if [[ "${completionActionOption}" == "Log Out"* ]] || [[ "${completionActionOption}" == "Sleep"* ]] || [[ "${completionActionOption}" == "Quit" ]] || [[ "${completionActionOption}" == "wait" ]] ; then
+		toggleJamfLaunchDaemon
+	fi
     
     # Remove welcomeCommandFile
     if [[ -e ${welcomeCommandFile} ]]; then


### PR DESCRIPTION
Currently the toggleJamfLaunchDaemon trigger is commented out in the QuitScript function but should be executed if the CompletionActionOption results in the Mac not being shut down or restarted. This PR adds an if statement to check if the CompletionActionOption is one where the ToggleJamfLaunchDaemon function should be triggered