### PR TITLE
Lock continue button until estimations are complete

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -140,7 +140,8 @@ supportKB="KB86753099"
 supportTeamErrorKB=", and mention [${supportKB}](https://servicenow.company.com/support?id=kb_article_view&sysparm_article=${supportKB}#Failures)"
 supportTeamHelpKB="\n- **Knowledge Base Article:** ${supportKB}"
 
-
+# Option to lock the Continue button in the User Input Welcome dialog until after the estimations are complete (true|false)
+lockContinueBeforeEstimations="true"
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Operating System, Computer Model Name, etc.
@@ -2300,6 +2301,11 @@ function checkNetworkQualityConfigurations() {
     updateScriptLog "WELCOME DIALOG: Network Quality Test: Started: $dlStartDate, Ended: $dlEndDate; Download: $mbps Mbps, Responsiveness: $dlResponsiveness"
     dialogUpdateWelcome "infobox: **Connection:**  \n- Download:  \n$mbps Mbps  \n\n**Estimates:**  \n- ${configurationOneName}:  \n$(printf '%dh:%dm:%ds\n' $((configurationOneEstimatedSeconds/3600)) $((configurationOneEstimatedSeconds%3600/60)) $((configurationOneEstimatedSeconds%60)))  \n\n- ${configurationTwoName}:  \n$(printf '%dh:%dm:%ds\n' $((configurationTwoEstimatedSeconds/3600)) $((configurationTwoEstimatedSeconds%3600/60)) $((configurationTwoEstimatedSeconds%60)))  \n\n- ${configurationThreeName}:  \n$(printf '%dh:%dm:%ds\n' $((configurationThreeEstimatedSeconds/3600)) $((configurationThreeEstimatedSeconds%3600/60)) $((configurationThreeEstimatedSeconds%60)))"
 
+    # If option to lock the continue button is set to true, enable the continue button now to let the user progress
+    if [[ "$lockContinueBeforeEstimations" = "true" ]]; then
+        updateScriptLog "WELCOME DIALOG: Enabling Continue Button"
+        dialogUpdateWelcome "button1: enable"
+    fi
 }
 
 
@@ -2710,8 +2716,18 @@ elif [[ "${welcomeDialog}" == "userInput" ]]; then
         updateScriptLog "WELCOME DIALOG: Write 'welcomeJSON' to $welcomeJSONFile …"
         echo "$welcomeJSON" > "$welcomeJSONFile"
 
-        updateScriptLog "WELCOME DIALOG: Display 'Welcome' dialog …"
-        welcomeResults=$( eval "${dialogBinary} --jsonfile ${welcomeJSONFile} --json" )
+        # If option to lock the continue button is set to true, open welcome dialog with button 1 disabled
+        if [[ "$lockContinueBeforeEstimations" = "true" ]]; then
+            
+            updateScriptLog "WELCOME DIALOG: Display 'Welcome' dialog with disabled Continue Button …"
+            welcomeResults=$( eval "${dialogBinary} --jsonfile ${welcomeJSONFile} --json --button1disabled" )
+            
+        else
+
+            updateScriptLog "WELCOME DIALOG: Display 'Welcome' dialog …"
+            welcomeResults=$( eval "${dialogBinary} --jsonfile ${welcomeJSONFile} --json" )
+
+        fi
 
     else
 


### PR DESCRIPTION
Do you hear that your users are forcing through the setup too quickly, perhaps clicking wrong things, or not making informed decisions on how long the configurations are going to take? How often do you hear them say "this process takes too long" only to find out they picked your most complete configuration and have no idea what you're talking about when you ask how long did the estimations take? Do you wish your users would just wait the few seconds for the estimations to appear before clicking through your input requirements? Well now you can make that happen, with the all new "Lock Continue Button" option!

If you set the "lockContinueBeforeEstimations" variable to true, the "continue" button (button1 of the dialog window, it doesn't matter what text was given for it) will be disabled when the dialog window opens up by default, and will not become enabled until after the estimations are written to the screen. This effectively forces the users to have to wait until they are able to be informed on how long the process could take.

Changes to code:
- Added variable to enable this setting at the top (true|false).
- Added if statement to UserInput welcomeDialog opening code to see if setting is true, if so then opens dialog window with "button1disabled" parameter
- Added if statement in checkNetworkQualityConfigurations function to see if setting is true, if so then enables button1
