### PR TITLE
Updated loggedInUserFirstname

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -286,7 +286,7 @@ until { [[ "${loggedInUser}" != "_mbsetupuser" ]] || [[ "${counter}" -gt "180" ]
 done
 
 loggedInUserFullname=$( id -F "${loggedInUser}" )
-loggedInUserFirstname=$( echo "$loggedInUserFullname" | sed -E 's/^.*, // ; s/([^ ]*).*/\1/' | sed 's/\(.\{25\}\).*/\1…/' | awk '{print toupper(substr($0,1,1))substr($0,2)}' )
+loggedInUserFirstname=$( echo "$loggedInUserFullname" | sed -E 's/^.*, // ; s/([^ ]*).*/\1/' | sed 's/\(.\{25\}\).*/\1…/' | awk '{print ( $0 == toupper($0) ? toupper(substr($0,1,1))substr(tolower($0),2) : toupper(substr($0,1,1))substr($0,2) )}' )
 loggedInUserID=$( id -u "${loggedInUser}" )
 updateScriptLog "PRE-FLIGHT CHECK: Current Logged-in User First Name: ${loggedInUserFirstname}"
 updateScriptLog "PRE-FLIGHT CHECK: Current Logged-in User ID: ${loggedInUserID}"


### PR DESCRIPTION
Added a check to account for if the loggedInUser returns in all caps, as this sometimes happens with SSO Attributes.

Previously, if the name was in all caps, it stayed that way when presenting the dialog to the user: 
![Screenshot 2023-07-19 at 12 33 06 PM](https://github.com/dan-snelson/Setup-Your-Mac/assets/30540357/95b8c75a-209b-4cce-a711-bacdb782a1a0)

With the added check in the loggedInUserFirstname, it now looks to see if the name is in all caps and corrects the case, while also still working for other cases: 
![Screenshot 2023-07-19 at 12 34 55 PM](https://github.com/dan-snelson/Setup-Your-Mac/assets/30540357/964f1a27-9746-44ba-9afa-8e57d9ae5fde)

