### PR TITLE
Add check for Filevault enabled at Setup Assistant

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -1880,7 +1880,8 @@ function validatePolicyResult() {
                     dialogUpdateSetupYourMac "listitem: index: $i, status: wait, statustext: Checking …"
                     updateScriptLog "SETUP YOUR MAC DIALOG: Validate Policy Result: Pausing for 5 seconds for FileVault … "
                     sleep 5 # Arbitrary value; tuning needed
-                    if [[ -f /Library/Preferences/com.apple.fdesetup.plist ]]; then
+                    fileVaultCheck=$( fdesetup isactive )
+                    if [[ -f /Library/Preferences/com.apple.fdesetup.plist ]] || [[ "$fileVaultCheck" == "true" ]]; then
                         fileVaultStatus=$( fdesetup status -extended -verbose 2>&1 )
                         case ${fileVaultStatus} in
                             *"FileVault is On."* ) 


### PR DESCRIPTION
This adds a check for Filevault being enabled at Setup Assistant for macOS 14 Sonoma.
Enabling FileVault in this way does not leave a breadcrumb on the disk so we need to use the built-in `fdesetup` binary to check whether FileVault is enabled or not.