### PR TITLE
Hiding unused Support Variables

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -550,7 +550,17 @@ failureCommandFile=$( mktemp -u /var/tmp/dialogCommandFileFailure.XXX )
 
 welcomeTitle="Happy $( date +'%A' ), ${loggedInUserFirstname}!  \nWelcome to your new ${modelName}"
 
-welcomeMessage="Please enter the **required** information for your ${modelName}, select your preferred **Configuration** then click **Continue** to start applying settings to your new Mac. \n\nOnce completed, the **Wait** button will be enabled and you‘ll be able to review the results before restarting your ${modelName}.  \n\nIf you need assistance, please contact the ${supportTeamName} at  \n${supportTeamPhone} and mention ${supportKB}.  \n\n---"
+welcomeMessage="Please enter the **required** information for your ${modelName}, select your preferred **Configuration** then click **Continue** to start applying settings to your new Mac. \n\nOnce completed, the **Wait** button will be enabled and you‘ll be able to review the results before restarting your ${modelName}.  \n\nIf you need assistance, please contact the ${supportTeamName} at"
+
+if [ -n "$supportTeamPhone" ]; then
+  welcomeMessage+="\n${supportTeamPhone}"
+fi
+
+if [ -n "$supportKB" ]; then
+  welcomeMessage+=" and mention ${supportKB}"
+fi
+
+welcomeMessage+=".\n\n---"
 
 if { [[ "${promptForConfiguration}" == "true" ]] && [[ "${welcomeDialog}" != "messageOnly" ]]; } then
     welcomeMessage+="  \n\n#### Configurations  \n- **${configurationOneName}:** ${configurationOneDescription}  \n- **${configurationTwoName}:** ${configurationTwoDescription}  \n- **${configurationThreeName}:** ${configurationThreeDescription}"
@@ -744,7 +754,26 @@ fi
 if [[ "${brandingBannerDisplayText}" == "true" ]] ; then bannerText="Setting up ${loggedInUserFirstname}‘s ${modelName}";
 else bannerText=""; fi
 
-helpmessage="If you need assistance, please contact the ${supportTeamName}:  \n- **Telephone:** ${supportTeamPhone}  \n- **Email:** ${supportTeamEmail}  ${supportTeamHelpKB}  \n\n**Computer Information:**  \n- **Operating System:**  ${macOSproductVersion} (${macOSbuildVersion})  \n- **Serial Number:** ${serialNumber}  \n- **Dialog:** ${dialogVersion}  \n- **Started:** ${timestamp}"
+helpmessage="If you need assistance, please contact the ${supportTeamName}:\n"
+
+if [ -n "$supportTeamPhone" ]; then
+  helpmessage+="- **Telephone:** ${supportTeamPhone}\n"
+fi
+
+if [ -n "$supportTeamEmail" ]; then
+  helpmessage+="- **Email:** ${supportTeamEmail}\n"
+fi
+
+if [ -n "$supportTeamHelpKB" ]; then
+  helpmessage+="${supportTeamHelpKB}\n"
+fi
+
+helpmessage+="\n**Computer Information:**\n"
+helpmessage+="- **Operating System:** ${macOSproductVersion} (${macOSbuildVersion})\n"
+helpmessage+="- **Serial Number:** ${serialNumber}\n"
+helpmessage+="- **Dialog:** ${dialogVersion}\n"
+helpmessage+="- **Started:** ${timestamp}"
+
 infobox="Analyzing input …" # Customize at "Update Setup Your Mac's infobox"
 
 # Check if the custom bannerImage is available, and if not, use a alternative image
@@ -1593,7 +1622,28 @@ function finalise(){
             updateScriptLog "Jamf Pro Policy Name Failures:"
             updateScriptLog "${jamfProPolicyNameFailures}"
 
-            dialogUpdateFailure "message: A failure has been detected, ${loggedInUserFirstname}. \n\nPlease complete the following steps:\n1. Reboot and login to your ${modelName}  \n2. Login to Self Service  \n3. Re-run any failed policy listed below  \n\nThe following failed:  \n${jamfProPolicyNameFailures}  \n\n\n\nIf you need assistance, please contact the ${supportTeamName},  \n${supportTeamPhone}${supportTeamErrorKB}. "
+
+            failureMessage="A failure has been detected, ${loggedInUserFirstname}. \n\nPlease complete the following steps:\n1. Reboot and login to your ${modelName}  \n2. Login to Self Service  \n3. Re-run any failed policy listed below  \n\nThe following failed:  \n${jamfProPolicyNameFailures}"
+
+            supportContactMessage="If you need assistance, please contact the ${supportTeamName},"
+
+            if [[ -n "${supportTeamPhone}" || -n "${supportTeamErrorKB}" ]]; then
+
+                if [[ -n "${supportTeamPhone}" ]]; then
+                    supportContactMessage+="\n ${supportTeamPhone}"
+                fi
+
+                if [[ -n "${supportTeamErrorKB}" ]]; then
+                    supportContactMessage+="${supportTeamErrorKB}"
+                fi
+
+                supportContactMessage+="."
+
+                failureMessage+="\n\n${supportContactMessage}"
+            fi
+
+            dialogUpdateFailure "message: ${failureMessage}"
+
             dialogUpdateFailure "icon: SF=xmark.circle.fill,weight=bold,colour1=#BB1717,colour2=#F31F1F"
             dialogUpdateFailure "button1text: ${button1textCompletionActionOption}"
 
@@ -3064,7 +3114,26 @@ if [[ "${symConfiguration}" != *"Catch-all"* ]]; then
 
         updateScriptLog "Update 'helpmessage' with Configuration: ${infoboxConfiguration} …"
 
-        helpmessage="If you need assistance, please contact the ${supportTeamName}:  \n- **Telephone:** ${supportTeamPhone}  \n- **Email:** ${supportTeamEmail}  \n- **Knowledge Base Article:** ${supportKB}  \n\n**Configuration:** \n- ${infoboxConfiguration}  \n\n**Computer Information:**  \n- **Operating System:**  ${macOSproductVersion} (${macOSbuildVersion})  \n- **Serial Number:** ${serialNumber}  \n- **Dialog:** ${dialogVersion}  \n- **Started:** ${timestamp}"
+        helpmessage="If you need assistance, please contact the ${supportTeamName}:\n"
+
+        if [ -n "$supportTeamPhone" ]; then
+        helpmessage+="- **Telephone:** $supportTeamPhone\n"
+        fi
+
+        if [ -n "$supportTeamEmail" ]; then
+        helpmessage+="- **Email:** $supportTeamEmail\n"
+        fi
+
+        if [ -n "$supportKB" ]; then
+        helpmessage+="- **Knowledge Base Article:** $supportKB\n"
+        fi
+
+        helpmessage+="\n**Configuration:**\n- $infoboxConfiguration\n"
+        helpmessage+="\n**Computer Information:**\n"
+        helpmessage+="- **Operating System:** $macOSproductVersion ($macOSbuildVersion)\n"
+        helpmessage+="- **Serial Number:** $serialNumber\n"
+        helpmessage+="- **Dialog:** $dialogVersion\n"
+        helpmessage+="- **Started:** $timestamp\n"
         
     fi
 

--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -764,7 +764,7 @@ if [ -n "$supportTeamEmail" ]; then
   helpmessage+="- **Email:** ${supportTeamEmail}\n"
 fi
 
-if [ -n "$supportTeamHelpKB" ]; then
+if [ -n "$supportKB" ]; then
   helpmessage+="${supportTeamHelpKB}\n"
 fi
 
@@ -1627,13 +1627,13 @@ function finalise(){
 
             supportContactMessage="If you need assistance, please contact the ${supportTeamName},"
 
-            if [[ -n "${supportTeamPhone}" || -n "${supportTeamErrorKB}" ]]; then
+            if [[ -n "${supportTeamPhone}" || -n "${supportKB}" ]]; then
 
                 if [[ -n "${supportTeamPhone}" ]]; then
                     supportContactMessage+="\n ${supportTeamPhone}"
                 fi
 
-                if [[ -n "${supportTeamErrorKB}" ]]; then
+                if [[ -n "${supportKB}" ]]; then
                     supportContactMessage+="${supportTeamErrorKB}"
                 fi
 

--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -149,7 +149,7 @@ brandingIconDark="https://cdn-icons-png.flaticon.com/512/740/740878.png"
 # IT Support Variables - Use these if the default text is fine but you want your org's info inserted instead
 supportTeamName="Help Desk"
 supportTeamPhone="+1 (801) 555-1212"
-supportTeamEmail="support@domain.org"
+supportTeamEmail=""
 supportKB="KB86753099"
 supportTeamErrorKB=", and mention [${supportKB}](https://servicenow.company.com/support?id=kb_article_view&sysparm_article=${supportKB}#Failures)"
 supportTeamHelpKB="\n- **Knowledge Base Article:** ${supportKB}"
@@ -584,11 +584,15 @@ if [ -n "$supportTeamName" ]; then
   welcomeMessage+="\n\nIf you need assistance, please contact the ${supportTeamName} at"
 
     if [ -n "$supportTeamPhone" ]; then
-    welcomeMessage+="\n${supportTeamPhone}"
+        welcomeMessage+="\n${supportTeamPhone}"
     fi
 
     if [ -n "$supportKB" ]; then
-    welcomeMessage+=" and mention ${supportKB}"
+        welcomeMessage+=" and mention ${supportKB}"
+    fi
+
+    if [ -n "$supportTeamEmail" ]; then
+        welcomeMessage+="\n${supportTeamEmail}"
     fi
 fi
 
@@ -1658,24 +1662,25 @@ function finalise(){
 
             failureMessage="A failure has been detected, ${loggedInUserFirstname}. \n\nPlease complete the following steps:\n1. Reboot and login to your ${modelName}  \n2. Login to Self Service  \n3. Re-run any failed policy listed below  \n\nThe following failed:  \n${jamfProPolicyNameFailures}"
             
-            if [ -n "$supportTeamName" ]; then
+            if [[ -n "$supportTeamName" ]]; then
                 supportContactMessage+="If you need assistance, please contact the ${supportTeamName},"
-            fi
 
-            if [[ -n "${supportTeamPhone}" || -n "${supportKB}" ]]; then
+                if [[ -n "$supportTeamEmail" ]]; then
+                    supportContactMessage+="\n${supportTeamEmail}"
+                fi
 
                 if [[ -n "${supportTeamPhone}" ]]; then
-                    supportContactMessage+="\n ${supportTeamPhone}"
+                    supportContactMessage+="\n${supportTeamPhone}"
                 fi
 
                 if [[ -n "${supportKB}" ]]; then
-                    supportContactMessage+="${supportTeamErrorKB}"
+                    supportContactMessage+="\n${supportTeamErrorKB}"
                 fi
-
-                supportContactMessage+="."
-
-                failureMessage+="\n\n${supportContactMessage}"
+            supportContactMessage+="."
             fi
+
+
+            failureMessage+="\n\n${supportContactMessage}"
 
             dialogUpdateFailure "message: ${failureMessage}"
 
@@ -3171,22 +3176,22 @@ if [[ "${symConfiguration}" != *"Catch-all"* ]]; then
 
         updateScriptLog "Update 'helpmessage' with Configuration: ${infoboxConfiguration} …"
 
-        helpmessage="If you need assistance, "
+        helpmessage="If you need assistance...\n "
         
-        if [ -n "$supportTeamName"]; then
-        helpmessage="please contact the ${supportTeamName}:\n"
+        if [ -n "$supportTeamName" ]; then
+            helpmessage+="Please contact the $supportTeamName:\n"
         fi
 
         if [ -n "$supportTeamPhone" ]; then
-        helpmessage+="- **Telephone:** $supportTeamPhone\n"
+            helpmessage+="- **Telephone:** $supportTeamPhone\n"
         fi
 
         if [ -n "$supportTeamEmail" ]; then
-        helpmessage+="- **Email:** $supportTeamEmail\n"
+            helpmessage+="- **Email:** $supportTeamEmail\n"
         fi
 
         if [ -n "$supportKB" ]; then
-        helpmessage+="- **Knowledge Base Article:** $supportKB\n"
+            helpmessage+="- **Knowledge Base Article:** $supportKB\n"
         fi
 
         helpmessage+="\n**Configuration:**\n- $infoboxConfiguration\n"


### PR DESCRIPTION
Adding If switches to only include existing support values.
My use case here is that I don't have either KB articles or a support cell phone number that would work here.

Hopefully this proves useful going forward in accommodating other similar use cases.

With values: 
![image](https://github.com/dan-snelson/Setup-Your-Mac/assets/64256007/3bc8defd-1915-48a7-a77e-5a7b0eaeb1f2)
![image](https://github.com/dan-snelson/Setup-Your-Mac/assets/64256007/11fc82da-b122-494d-8a1c-a6ce2601ef5b)

Without Values:
![image](https://github.com/dan-snelson/Setup-Your-Mac/assets/64256007/7d6c8942-d228-4b18-a063-6fe117d26d46)
![image](https://github.com/dan-snelson/Setup-Your-Mac/assets/64256007/018f8804-8a77-4e00-b0df-f40f420f29d5)
