### PR TITLE
Add failure indication for local validation catch all

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -2085,7 +2085,11 @@ function validatePolicyResult() {
                     fi
                     ;;
                 * )
-                    updateScriptLog "SETUP YOUR MAC DIALOG: Locally Validate Policy Results Local Catch-all: ${validation}"
+                    updateScriptLog "SETUP YOUR MAC DIALOG: Locally Validate Policy Result: Local Validation “${validation}” Missing"
+                    dialogUpdateSetupYourMac "listitem: index: $i, status: fail, statustext: Missing Local Validation"
+                    jamfProPolicyTriggerFailure="failed"
+                    exitCode="1"
+                    jamfProPolicyNameFailures+="• $listitem  \n"
                     ;;
             esac
             ;;


### PR DESCRIPTION
This adds a failure indication when a "Local" validation trigger does not exist in the main script.
It marks the policy as failed even if the preceding trigger succeeded as it is unable to be properly validated.
The list status text reflects the missing validation so the end user can alert support as well.