### PR TITLE
Added OS Build number to webhook output

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -2527,7 +2527,7 @@ function webHookMessage() {
                         },
                         {
                             "type": "mrkdwn",
-                            "text": "*OS Version:*\n${osVersion}"
+                            "text": "*OS Version:*\n${osVersion} (${osBuild})"
                         },
                         {
                             "type": "mrkdwn",
@@ -2598,7 +2598,7 @@ EOF
             "value": "${loggedInUser}"
         }, {
             "name": "Operating System Version",
-            "value": "${osVersion}"
+            "value": "${osVersion} (${osBuild})"
         }, {
             "name": "Additional Comments",
             "value": "${jamfProPolicyNameFailures}"


### PR DESCRIPTION
Adds the current build number to the webhook output of Teams and Slack.

**NOTE:** Please Test! This is currently untested as I can't call the webhook without doing an actual install.